### PR TITLE
! allow low-level conversation access in widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v0.2
+
+* type rename: `Conversation -> ConversationHandler`.
+* introduce `lowLevel` prop in widget, allowing access to the conversation handler.
+* support `payload` when subscribing to new messages.
+
+## v0.1.x
+
+Initial versions.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ convo.sendText("hello");
 
 ## API reference
 
-The package exports a single function called `createConversation`, which is called with the bot configuration and returns a conversation object. This object has the following methods:
+The package exports a single function called `createConversation`, which is called with the bot configuration and returns a conversation handler object. This object has the following methods:
 
 #### `sendText: (text: string) => void`
 
@@ -36,11 +36,11 @@ Send a simple text to your bot.
 
 Your bot may send a list of choices to choose from, each with a `choiceText` and a `choiceId` field. You can use `choiceText` as button labels, and include the `choiceId` in this method when sending responses.
 
-#### `subscribe: (subscriber: (messages: Message[]) => void) => void`
+#### `subscribe: (subscriber: (messages: Message[], additional: { payload?: string }) => void) => void`
 
 Subscribe to the current state of messages whenever there is a change.
 
-#### `unsubscribe: (subscriber: (messages: Message[]) => void) => void`
+#### `unsubscribe: (subscriber: (messages: Message[], additional: { payload?: string }) => void) => void`
 
 Remove a subscription.
 

--- a/examples/widget.tsx
+++ b/examples/widget.tsx
@@ -19,5 +19,10 @@ standalone({
       "https://images.unsplash.com/photo-1558470622-bd37a3c489e7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
   },
   inputPlaceholder: "Say something...",
-  initiallyExpanded: true
+  initiallyExpanded: true,
+  lowLevel: conversation => {
+    // console.log(conversation);
+    // conversation.subscribe(messages => {});
+    // etc.
+  }
 });

--- a/examples/with-react.tsx
+++ b/examples/with-react.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { render } from "react-dom";
 import createConversation, {
   Config,
-  Conversation,
+  ConversationHandler,
   Message
 } from "../src/index";
 import { useChat } from "../src/react-utils";
@@ -33,7 +33,7 @@ const App = () => {
               <button
                 key={choiceIndex}
                 onClick={() => {
-                  chat.sendChoice(choice.choiceId);
+                  chat.conversationHandler.sendChoice(choice.choiceId);
                 }}
               >
                 {choice.choiceText}
@@ -59,7 +59,7 @@ const App = () => {
           if (!chat) {
             return;
           }
-          chat.sendText(chat.inputValue);
+          chat.conversationHandler.sendText(chat.inputValue);
           chat.setInputValue("");
         }}
       >

--- a/src/react-utils/index.ts
+++ b/src/react-utils/index.ts
@@ -1,21 +1,23 @@
 import * as React from "react";
-import createConversation, { Config, Conversation, Message } from "../index";
+import createConversation, {
+  Config,
+  ConversationHandler,
+  Message
+} from "../index";
 
 export const useChat = (
   config: Config
 ): {
-  messages: Message[];
+  conversationHandler: ConversationHandler;
   inputValue: string;
-  setInputValue: (val: string) => void;
-  sendText: Conversation["sendText"];
-  sendChoice: Conversation["sendChoice"];
-  currentConversationId: Conversation["currentConversationId"];
-  reset: Conversation["reset"];
+  messages: Message[];
   messagesContainerRef: React.Ref<HTMLDivElement> | null;
+  setInputValue: (val: string) => void;
 } | null => {
-  const [conversation, setConversation] = React.useState<null | Conversation>(
-    null
-  );
+  const [
+    conversation,
+    setConversation
+  ] = React.useState<null | ConversationHandler>(null);
 
   const [messages, setMessages] = React.useState<Message[]>([]);
 
@@ -52,13 +54,10 @@ export const useChat = (
   }
 
   return {
+    conversationHandler: conversation,
     inputValue,
-    setInputValue,
-    currentConversationId: conversation.currentConversationId,
-    sendText: conversation.sendText,
-    sendChoice: conversation.sendChoice,
-    reset: conversation.reset,
-    messagesContainerRef: messagesContainerRef,
-    messages
+    messages,
+    messagesContainerRef,
+    setInputValue
   };
 };

--- a/src/widget/README.md
+++ b/src/widget/README.md
@@ -69,3 +69,22 @@ When set to a non-empty string, a small bubble will appear above the chat pin wh
 
 A complete example of the configuration options can be found [here](../../examples/standalone.html).
 
+### `initiallyExpanded`
+
+Sets whether the widget is initially expanded.
+
+### `lowLevel`
+
+If you need low-level control of the widget, this configuration value gives access to the `conversationHandler` object through a callback:
+
+```jsx
+<Widget
+  {/* ... */}
+  lowLevel={conversationHandler => {
+    conversationHandler.subscribe(() => {
+    });
+  }
+/>
+```
+
+The callback pattern works similarly to the way [callback refs](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) work in React. We are avoiding that naming since the configuration option works identical in standalone mode.

--- a/src/widget/index.tsx
+++ b/src/widget/index.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { render, unmountComponentAtNode } from "react-dom";
 import createConversation, {
   Config,
-  Conversation,
+  ConversationHandler,
   Message,
   findSelectedChoice
 } from "../index";
@@ -40,6 +40,12 @@ export const Widget: React.SFC<Props> = props => {
   // Chat
 
   const chat = useChat(props.config);
+
+  React.useEffect(() => {
+    if (props.lowLevel && chat && chat.conversationHandler) {
+      props.lowLevel(chat.conversationHandler);
+    }
+  }, [chat && chat.conversationHandler]);
 
   // Expanded state
 
@@ -93,7 +99,7 @@ export const Widget: React.SFC<Props> = props => {
     chat &&
     chat.inputValue.replace(/ /gi, "") !== "" &&
     (() => {
-      chat.sendText(chat.inputValue);
+      chat.conversationHandler.sendText(chat.inputValue);
       chat.setInputValue("");
     });
 
@@ -134,7 +140,7 @@ export const Widget: React.SFC<Props> = props => {
                                 ? transcript.html({
                                     messages: chat.messages,
                                     titleBar: props.titleBar,
-                                    conversationId: chat.currentConversationId()
+                                    conversationId: chat.conversationHandler.currentConversationId()
                                   })
                                 : ""
                             ],
@@ -203,7 +209,9 @@ export const Widget: React.SFC<Props> = props => {
                                           }
                                         : {
                                             onClick: () => {
-                                              chat.sendChoice(choice.choiceId);
+                                              chat.conversationHandler.sendChoice(
+                                                choice.choiceId
+                                              );
                                             }
                                           };
                                     })()}

--- a/src/widget/types.ts
+++ b/src/widget/types.ts
@@ -1,4 +1,4 @@
-import createConversation, { Config } from "../index";
+import createConversation, { Config, ConversationHandler } from "../index";
 
 export interface Props {
   config: Config;
@@ -12,6 +12,7 @@ export interface Props {
   bubble?: string;
   inputPlaceholder?: string;
   initiallyExpanded?: boolean;
+  lowLevel?: (conversationHandler: ConversationHandler) => void;
 }
 
 // Colors may be in any CSS-compatible format like rgb(50, 50, 50) or #aaa


### PR DESCRIPTION
The widget now gives access to its low-level `Conversation` instance through an optional `accessLowLevelConversation` prop. This is advanced usage allowing outside parts of the page react to messages, in both directions.