### PR TITLE
feature: Add configurationId option to chat SDK configuration.

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,6 +13,7 @@ const config = {
   headers: {
     "nlx-api-key": "" // obtain from NLX deployments page
   },
+  conversationId: "", // optional Resume an existing conversation. Obtain from a response from the bot
   userId: "abcd-1234", // optional property to identify the user
   context: {}, // context that is shared with the bot
   triggerWelcomeIntent: true, // set whether the welcome intent should trigger when the conversation is initialized

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ export type Time = number;
 export interface Config {
   botUrl: string;
   userId?: string;
+  conversationId?: string | undefined,
   failureMessages?: string[];
   greetingMessages?: string[];
   context?: Record<string, any>;
@@ -171,7 +172,7 @@ export const createConversation = (config: Config): ConversationHandler => {
               type: "bot",
               receivedAt: new Date().getTime(),
               payload: {
-                conversationId: undefined,
+                conversationId: config.conversationId,
                 messages: config.greetingMessages.map(
                   (greetingMessage: string) => ({
                     messageId: undefined,
@@ -185,7 +186,7 @@ export const createConversation = (config: Config): ConversationHandler => {
           ]
         : [],
     userId: config.userId,
-    conversationId: uuid(),
+    conversationId: config.conversationId || uuid(),
     contextSent: false,
   };
 


### PR DESCRIPTION
Modified the core chat SDK to add *configurationId* to configuration so that you can attach/resume an existing conversation.

This feature is required to provide the Alice Platform Channel. Since Lambdas are stateless need to associate the reservation   id with conversational id and persist so that two-way communication is synchronized.