### PR TITLE
chore: add workflow

### DIFF
--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -1,0 +1,22 @@
+name: Test project files on push
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+            node-version: '16'
+      - name: Installing node_modules
+        run: npm install
+      # - name: Running tests
+      #   run: npm run test
+      - name: Build the app
+        run: cd packages/app && npm run build

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -16,7 +16,5 @@ jobs:
             node-version: '16'
       - name: Installing node_modules
         run: npm install
-      # - name: Running tests
-      #   run: npm run test
       - name: Build the app
-        run: cd packages/app && npm run build
+        run: npm run build


### PR DESCRIPTION
added workflow to run `npm run build` on pushes and prs, at least some auto error protection. But we need to enable it in repo settings, I've no enough rights.